### PR TITLE
Restyle version links to use GitHub classes

### DIFF
--- a/src/pull-request-show-all-comments.js
+++ b/src/pull-request-show-all-comments.js
@@ -19,13 +19,13 @@ ExpandCommentsHack.prototype = {
         btnExpandComments.classList.add("btn-sm");
         btnExpandComments.classList.add("js-detials-target");
         btnExpandComments.innerHTML = "Expand Comments";
-        
+
         var btnContainer = headerActionsEl[0];
         btnContainer.insertBefore(
-            btnExpandComments, 
+            btnExpandComments,
             btnContainer.firstChild);
 
-        var loadMore = function () {
+        function loadMore() {
             var loadMoreButtons = document.getElementsByClassName('ajax-pagination-btn');
 
             Array
@@ -36,7 +36,7 @@ ExpandCommentsHack.prototype = {
             return loadMoreButtons.length;
         };
 
-        var expandAllComments = function () {
+        function expandAllComments() {
             var outdatedButtons =
                 Array
                     .from(document.querySelectorAll('summary.js-toggle-outdated-comments'))
@@ -44,11 +44,11 @@ ExpandCommentsHack.prototype = {
             outdatedButtons.forEach(x => window.setTimeout(x.click.bind(x), 0));
         };
 
-        var updateButtonStatus = function(val){
+        function updateButtonStatus(val){
             btnExpandComments.innerHTML = val;
         };
 
-        var continouslyCheckInAndLoad = function () {
+        function continouslyCheckInAndLoad() {
             updateButtonStatus('⏳ Expanding');
             var loadingCount = loadMore();
             var loadedStuff = loadingCount > 0;
@@ -62,12 +62,12 @@ ExpandCommentsHack.prototype = {
             }
         };
 
-        var addCommentController = function(){
+        function addCommentController(){
             updateButtonStatus('✅ Remove Completed Comments');
-            btnExpandComments.onclick = killAllCommentsRespondedTo; 
+            btnExpandComments.onclick = killAllCommentsRespondedTo;
         };
 
-        var killAllCommentsRespondedTo = function(){
+        function killAllCommentsRespondedTo(){
             var remaining = 0;
             var mainCommentContainers = Array.from(document.getElementsByClassName('file js-comment-container'));
             mainCommentContainers.forEach(x => {
@@ -76,7 +76,7 @@ ExpandCommentsHack.prototype = {
                 if (lastComment == null){
                     return;
                 }
-                var hasThumbsUp = 
+                var hasThumbsUp =
                     Array.from(lastComment.getElementsByClassName('emoji mr-1'))
                     .filter(x => x.innerHTML == '👍')
                     .length > 0;
@@ -91,44 +91,51 @@ ExpandCommentsHack.prototype = {
 
         btnExpandComments.onclick = continouslyCheckInAndLoad;
 
+        var versionLinkClass = "hubberdashery-version-link";
 
         /*
         * Version Links
         */
-       var createVersionLink = function(
-            link, 
+       function createVersionLink(
+            link,
             branchName,
             name){
-        
+
             var base = link.href.substring(0, link.href.indexOf('/pull'));
             var file = link.title.trim();
             var href = base + '/blob/' + branchName + '/' + file;
             var viewLink = document.createElement("a");
-            viewLink.classList.add("file-info");
-            viewLink.classList.add("link-gray-dark");
-            viewLink.style = "background-color: #e9e9e9;padding:5px;";
+            viewLink.classList.add("Counter");
+            viewLink.classList.add(versionLinkClass);
             viewLink.innerHTML = name;
             viewLink.href = href;
             viewLink.target = "_blank";
             return viewLink;
         };
-        
-        var getBranchName = function(){
+
+        function getBranchName(){
             var commitRefs = document.getElementsByClassName('commit-ref');
             var span = commitRefs[1].getElementsByClassName('css-truncate-target')[0];
             return span.innerHTML.trim();
         };
-        
-        var createDivider = function(){
+
+        function createDivider(){
             var span = document.createElement("span");
             span.innerHTML = "&nbsp;";
             return span;
         };
-        
-        var addVersionLinks = function(){
+
+        var hasVersionLinks = [];
+
+        function addVersionLinks(){
             var branchName = getBranchName();
             var links = Array.from(document.querySelectorAll('a.file-info'));
             links.forEach(x => {
+                var idx = hasVersionLinks.indexOf(x);
+                if (idx > -1) {
+                    return;
+                }
+                hasVersionLinks.push(x);
                 var viewLatest = createVersionLink(x, branchName, "@head");
                 x.parentNode.appendChild(viewLatest);
                 x.parentNode.appendChild(createDivider());


### PR DESCRIPTION
Allows restyling tools like Stylish to work properly

before:
![image](https://user-images.githubusercontent.com/4669340/43520220-75210ea8-9592-11e8-8b82-69038703b871.png)


after:
![image](https://user-images.githubusercontent.com/4669340/43520088-01ffa830-9592-11e8-80c6-c26025b15fca.png)

in addition, this PR stores a collection of the file headers where the links have been added to prevent accidentally adding them twice (eg via two clicks in quick succession)